### PR TITLE
Update to 1.3.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "mosh" %}
-{% set version = "1.2.6" %}
-{% set sha256 = "82b4c52adc527d802351a4d1ba0b193ee3dfc9b3e203b4919516f6ae0e471a72" %}
+{% set version = "1.3.2" %}
+{% set sha256 = "da600573dfa827d88ce114e0fed30210689381bbdcff543c931e4d6a2e851216" %}
 
 package:
   name: {{ name|lower }}
@@ -12,23 +12,22 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 3
+  number: 1
   skip: True  # [win]
 
 requirements:
   build:
-    - toolchain
     - pkg-config
     - protobuf
     - libprotobuf  # [linux]
-    - ncurses 5.9*
+    - ncurses 6.*
     - zlib 1.2.*
     - openssl 1.0.*
     - perl
   run:
     - libprotobuf  # [linux]
     - protobuf  # [osx]
-    - ncurses 5.9*
+    - ncurses 6.*
     - zlib 1.2.*
     - openssl 1.0.*
     - perl


### PR DESCRIPTION
- Updated to 1.3.2
- Build number reset to 1
- toolchain builddep removed
- ncurses dep updated to > 6.x