### PR TITLE
Use libprotobuf 3.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,13 +19,13 @@ requirements:
   build:
     - toolchain
     - pkg-config
-    - protobuf 3.5.*
+    - libprotobuf 3.5.*
     - ncurses 5.9*
     - zlib 1.2.11
     - openssl 1.0.*
     - perl
   run:
-    - protobuf 3.5.*
+    - libprotobuf 3.5.*
     - ncurses 5.9*
     - zlib 1.2.11
     - openssl 1.0.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,13 +19,13 @@ requirements:
   build:
     - toolchain
     - pkg-config
-    - protobuf 3.4.*
+    - protobuf 3.5.*
     - ncurses 5.9*
     - zlib 1.2.11
     - openssl 1.0.*
     - perl
   run:
-    - protobuf 3.4.*
+    - protobuf 3.5.*
     - ncurses 5.9*
     - zlib 1.2.11
     - openssl 1.0.*


### PR DESCRIPTION
Now that we have `libprotobuf` in conda-forge, switch over to it. Also switch to the latest version.